### PR TITLE
to_tsquery function

### DIFF
--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -150,8 +150,8 @@ pgTSVector = IPT.castToType "tsvector" . HSD.quote
 pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
-toTSQuery :: String -> Column Int
-toTSQuery q = C.Column (HPQ.FunExpr "to_tsquery" [q])
+toTSQuery :: String -> Column PGTSQuery
+toTSQuery q = C.Column (HPQ.FunExpr "to_tsquery" [HPQ.ConstExpr $ HPQ.StringLit q])
 
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -150,6 +150,9 @@ pgTSVector = IPT.castToType "tsvector" . HSD.quote
 pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
+toTSQuery :: C.PGString a => Column a -> Column Int
+toTSQuery (Column e) = Column (HPQ.FunExpr "to_tsquery" [e])
+
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)
 pgArray pgEl xs = C.unsafeCast arrayTy $

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -150,8 +150,8 @@ pgTSVector = IPT.castToType "tsvector" . HSD.quote
 pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
-toTSQuery :: C.PGString a => Column a -> Column Int
-toTSQuery (C.Column e) = C.Column (HPQ.FunExpr "to_tsquery" [e])
+toTSQuery :: String -> Column Int
+toTSQuery q = C.Column (HPQ.FunExpr "to_tsquery" [q])
 
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -151,7 +151,7 @@ pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
 toTSQuery :: C.PGString a => Column a -> Column Int
-toTSQuery (Column e) = C.Column (HPQ.FunExpr "to_tsquery" [e])
+toTSQuery (C.Column e) = C.Column (HPQ.FunExpr "to_tsquery" [e])
 
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -153,6 +153,9 @@ pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 toTSQuery :: String -> Column PGTSQuery
 toTSQuery q = C.Column (HPQ.FunExpr "to_tsquery" [HPQ.ConstExpr $ HPQ.StringLit q])
 
+plaintoTSQuery :: String -> Column PGTSQuery
+plaintoTSQuery q = C.Column (HPQ.FunExpr "plainto_tsquery" [HPQ.ConstExpr $ HPQ.StringLit q])
+
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)
 pgArray pgEl xs = C.unsafeCast arrayTy $

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -151,7 +151,7 @@ pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
 toTSQuery :: C.PGString a => Column a -> Column Int
-toTSQuery (Column e) = Column (HPQ.FunExpr "to_tsquery" [e])
+toTSQuery (C.Column e) = Column (HPQ.FunExpr "to_tsquery" [e])
 
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -151,7 +151,7 @@ pgTSQuery :: String -> Column PGTSQuery
 pgTSQuery = IPT.castToType "tsquery" . HSD.quote
 
 toTSQuery :: C.PGString a => Column a -> Column Int
-toTSQuery (C.Column e) = Column (HPQ.FunExpr "to_tsquery" [e])
+toTSQuery (Column e) = C.Column (HPQ.FunExpr "to_tsquery" [e])
 
 pgArray :: forall a b. IsSqlType b
         => (a -> C.Column b) -> [a] -> C.Column (PGArray b)


### PR DESCRIPTION
One should use `@@ to_tsquery('query')` to make successful searches. Previously it was: `@@ (CAST(E'query'))` which didn't work.

Haskell code should look more or less like this:
```haskell
(n^.ns_search_title) @@ (toTSQuery $ T.unpack query)
```
Note that this won't work (the `CAST`) case:
```haskell
(n^.ns_search_title) @@ (pgTSQuery (T.unpack query))
```